### PR TITLE
feat(seed): use FK-safe clear instead of unconditional TRUNCATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The function is configured through Azure App Settings / Environment variables, y
 | `SyncJobsConfig__Jobs__[key]__Tables__[key]`                             | Fully qualified name of table to sync                                                                                                        | `dbo.MyTable`                                                                |
 | `SyncJobsConfig__Jobs__[key]__DisableTargetIdentityInsertTables__[key]`  | Optional, per table. When `true`, merge does not use `IDENTITY_INSERT` on target (use when target has no identity column but source does).   | `true` or `false`                                                            |
 | `SyncJobsConfig__Jobs__[key]__DisableConstraintCheckTables__[key]`       | Optional, per table. When `true`, disables constraint checking during merge. Useful for tables with foreign key dependencies.                | `true` or `false`                                                            |
+| `SyncJobsConfig__Jobs__[key]__DeleteInsteadOfTruncateTables__[key]`      | Optional, per table. When `true`, forces DELETE + identity reseed instead of TRUNCATE when clearing target during seed. Auto-enabled when incoming FKs are detected. | `true` or `false`                                                            |
 
 
 > Note:
@@ -43,6 +44,8 @@ The function is configured through Azure App Settings / Environment variables, y
 > **DisableTargetIdentityInsertTables**: Omit or set to `false` to copy identity values from source (default). Set to `true` per table when the target schema has no identity column but the source does.
 >
 > **DisableConstraintCheckTables**: Omit or set to `false` to keep constraints enabled during merge (default). Set to `true` per table when syncing tables with foreign key dependencies that may cause constraint violations due to merge order.
+>
+> **DeleteInsteadOfTruncateTables**: During seed, the target table is cleared before bulk copy. `TRUNCATE` is used by default when the target is not referenced by foreign keys. When the target is referenced by other tables (detected automatically at schema load), or when this flag is `true`, the service uses `DELETE` with `NOCHECK`/`CHECK` on referencing tables and `DBCC CHECKIDENT` reseed when the target has an identity column. Set to `true` to force the delete path (e.g. replication or other TRUNCATE restrictions without FK).
 >
 > Configuration from KeyVault replace `__` with `--` i.e. `SyncJobsConfig--Jobs--MySync--Tables--MyTable`
 

--- a/src/SqlBulkSyncFunction/Functions/GetSyncJobConfig.GetJobConfig.cs
+++ b/src/SqlBulkSyncFunction/Functions/GetSyncJobConfig.GetJobConfig.cs
@@ -34,7 +34,8 @@ public partial class GetSyncJobConfig
                         Source: value.Value,
                         Target: jobConfig.TargetTables?.TryGetValue(value.Key, out var target) == true && !string.IsNullOrWhiteSpace(target) ? target : value.Value,
                         DisableTargetIdentityInsert: jobConfig.DisableTargetIdentityInsertTables.GetValueOrDefault(value.Key),
-                        DisableConstraintCheck: jobConfig.DisableConstraintCheckTables.GetValueOrDefault(value.Key)
+                        DisableConstraintCheck: jobConfig.DisableConstraintCheckTables.GetValueOrDefault(value.Key),
+                        DeleteInsteadOfTruncate: jobConfig.DeleteInsteadOfTruncateTables.GetValueOrDefault(value.Key)
                     )
                 ) ?? [];
             return new OkObjectResult(

--- a/src/SqlBulkSyncFunction/Helpers/SchemaExtensions.cs
+++ b/src/SqlBulkSyncFunction/Helpers/SchemaExtensions.cs
@@ -228,4 +228,23 @@ public static class SchemaExtensions
                         tp.name         <> 'timestamp'
                 """
             )];
+
+    /// <summary>
+    /// Returns fully qualified table names that have foreign keys referencing the specified table.
+    /// </summary>
+    /// <param name="conn">Database connection (typically target).</param>
+    /// <param name="tableName">Fully qualified table name to inspect.</param>
+    /// <returns>Distinct referencing table names.</returns>
+    public static string[] GetReferencingTables(this SqlConnection conn, string tableName)
+        => [.. conn.Query<string>(
+            commandTimeout: 180,
+            param: new { TableName = tableName },
+            sql:
+            """
+            SELECT DISTINCT
+                QUOTENAME(OBJECT_SCHEMA_NAME(fk.parent_object_id)) + '.' + QUOTENAME(OBJECT_NAME(fk.parent_object_id))
+                FROM sys.foreign_keys fk
+                WHERE fk.referenced_object_id = OBJECT_ID(@TableName)
+            """
+        )];
 }

--- a/src/SqlBulkSyncFunction/Helpers/SqlCommandExtensions.cs
+++ b/src/SqlBulkSyncFunction/Helpers/SqlCommandExtensions.cs
@@ -242,7 +242,7 @@ public static class SqlCommandExtensions
         logger.LogInformation("{Scope} {Result}", scope, qm.ReadFirst<string>());
     }
 
-    public static void TruncateTargetTable(
+    public static void ClearTargetTable(
         this SqlConnection targetConn,
         TableSchema tableSchema,
         object scope,
@@ -253,12 +253,26 @@ public static class SqlCommandExtensions
         {
             Connection = targetConn,
             CommandType = CommandType.Text,
-            CommandText = tableSchema.TruncateTargetTableStatement,
+            CommandText = tableSchema.ClearTargetTableStatement,
             CommandTimeout = 500000
         };
-        logger.LogInformation("{Scope} Truncating table {TargetTableName}...", scope, tableSchema.TargetTableName);
+
+        if (tableSchema.UseDeleteInsteadOfTruncate)
+        {
+            logger.LogInformation(
+                "{Scope} Clearing table {TargetTableName} using DELETE (referencing tables: {ReferencingTableCount})...",
+                scope,
+                tableSchema.TargetTableName,
+                tableSchema.ReferencingTables.Length
+                );
+        }
+        else
+        {
+            logger.LogInformation("{Scope} Clearing table {TargetTableName} using TRUNCATE...", scope, tableSchema.TargetTableName);
+        }
+
         _ = targetCmd.ExecuteNonQuery();
-        logger.LogInformation("{Scope} Truncated table {TargetTableName}.", scope, tableSchema.TargetTableName);
+        logger.LogInformation("{Scope} Cleared table {TargetTableName}.", scope, tableSchema.TargetTableName);
     }
 
     public static void BulkCopyDataDirect(

--- a/src/SqlBulkSyncFunction/Helpers/SqlStatementExtensions.cs
+++ b/src/SqlBulkSyncFunction/Helpers/SqlStatementExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using SqlBulkSyncFunction.Models.Schema;
 using SqlBulkSyncFunction.Models.Schema.Export;
 
@@ -513,8 +514,46 @@ public static class SqlStatementExtensions
         return statement;
     }
 
-    public static string GetTruncateTargetTableStatement(this TableSchema tableSchema)
-        => string.Concat("TRUNCATE TABLE ", tableSchema.TargetTableName);
+    /// <summary>
+    /// Builds the SQL batch used to clear the target table during seed operations.
+    /// Uses TRUNCATE when safe; otherwise DELETE with NOCHECK on referencing tables and identity reseed.
+    /// </summary>
+    /// <param name="tableSchema">Target table schema.</param>
+    /// <param name="useDeleteInsteadOfTruncate">When true, use DELETE instead of TRUNCATE.</param>
+    /// <param name="referencingTables">Tables with foreign keys referencing the target.</param>
+    /// <returns>SQL batch to clear the target table.</returns>
+    public static string GetClearTargetTableStatement(
+        this TableSchema tableSchema,
+        bool useDeleteInsteadOfTruncate,
+        string[] referencingTables
+        )
+    {
+        if (!useDeleteInsteadOfTruncate)
+        {
+            return string.Concat("TRUNCATE TABLE ", tableSchema.TargetTableName);
+        }
+
+        var statement = new StringBuilder();
+
+        foreach (var referencingTable in referencingTables)
+        {
+            _ = statement.AppendLine(FormattableString.Invariant($"ALTER TABLE {referencingTable} NOCHECK CONSTRAINT ALL;"));
+        }
+
+        _ = statement.AppendLine(FormattableString.Invariant($"DELETE FROM {tableSchema.TargetTableName};"));
+
+        if (tableSchema.Columns.Any(column => column.IsIdentity))
+        {
+            _ = statement.AppendLine(FormattableString.Invariant($"DBCC CHECKIDENT ('{tableSchema.TargetTableName}', RESEED, 0);"));
+        }
+
+        foreach (var referencingTable in referencingTables)
+        {
+            _ = statement.AppendLine(FormattableString.Invariant($"ALTER TABLE {referencingTable} CHECK CONSTRAINT ALL;"));
+        }
+
+        return statement.ToString();
+    }
 
     public static string GetSyncTableExistStatement(this TableSchema tableSchema)
         =>  $"""

--- a/src/SqlBulkSyncFunction/Helpers/SyncJobConfigExtensions.cs
+++ b/src/SqlBulkSyncFunction/Helpers/SyncJobConfigExtensions.cs
@@ -54,6 +54,12 @@ public static class SyncJobConfigExtensions
             StringComparer.OrdinalIgnoreCase
         );
 
+        var deleteInsteadOfTruncateTables = job.DeleteInsteadOfTruncateTables?.ToLookup(
+            key => key.Key,
+            value => value.Value,
+            StringComparer.OrdinalIgnoreCase
+        );
+
         return [.. job.Tables.Select(
             sourceTable => new SyncJobTable(
                 sourceTable.Key,
@@ -64,7 +70,8 @@ public static class SyncJobConfigExtensions
                     _ => sourceTable.Value
                 },
                 disableTargetIdentityInsertTables.GetValueOrDefault(sourceTable.Key),
-                disableConstraintCheckTables.GetValueOrDefault(sourceTable.Key)
+                disableConstraintCheckTables.GetValueOrDefault(sourceTable.Key),
+                deleteInsteadOfTruncateTables.GetValueOrDefault(sourceTable.Key)
             )
         )];
     }

--- a/src/SqlBulkSyncFunction/Models/Job/SyncJobConfig.cs
+++ b/src/SqlBulkSyncFunction/Models/Job/SyncJobConfig.cs
@@ -10,6 +10,7 @@ public record SyncJobConfig
     public Dictionary<string, string> TargetTables { get; init; } = [];
     public Dictionary<string, bool> DisableTargetIdentityInsertTables { get; init; } = [];
     public Dictionary<string, bool> DisableConstraintCheckTables { get; init; } = [];
+    public Dictionary<string, bool> DeleteInsteadOfTruncateTables { get; init; } = [];
     public int? BatchSize { get; init; }
     public string Area { get; init; }
     public bool? Manual { get; init; }

--- a/src/SqlBulkSyncFunction/Models/Job/SyncJobConfigResponse.cs
+++ b/src/SqlBulkSyncFunction/Models/Job/SyncJobConfigResponse.cs
@@ -10,11 +10,13 @@ namespace SqlBulkSyncFunction.Models.Job;
 /// <param name="Target">Target table name.</param>
 /// <param name="DisableTargetIdentityInsert">Whether target identity insert is disabled for this table.</param>
 /// <param name="DisableConstraintCheck">Whether constraint checking is disabled during merge operations for this table.</param>
+/// <param name="DeleteInsteadOfTruncate">Whether DELETE + reseed is used instead of TRUNCATE when clearing target during seed.</param>
 public record SyncJobConfigTableDto(
     [property: JsonPropertyName("source")] string Source,
     [property: JsonPropertyName("target")] string Target,
     [property: JsonPropertyName("disableTargetIdentityInsert")] bool DisableTargetIdentityInsert,
-    [property: JsonPropertyName("disableConstraintCheck")] bool DisableConstraintCheck
+    [property: JsonPropertyName("disableConstraintCheck")] bool DisableConstraintCheck,
+    [property: JsonPropertyName("deleteInsteadOfTruncate")] bool DeleteInsteadOfTruncate
 );
 
 /// <summary>

--- a/src/SqlBulkSyncFunction/Models/Job/SyncJobTable.cs
+++ b/src/SqlBulkSyncFunction/Models/Job/SyncJobTable.cs
@@ -8,10 +8,12 @@ namespace SqlBulkSyncFunction.Models.Job;
 /// <param name="Target">Target table name.</param>
 /// <param name="DisableTargetIdentityInsert">Whether to disable identity insert on target table during sync.</param>
 /// <param name="DisableConstraintCheck">Whether to disable constraint checking on target table during merge operations.</param>
+/// <param name="DeleteInsteadOfTruncate">Whether to use DELETE + reseed instead of TRUNCATE when clearing target during seed.</param>
 public record SyncJobTable(
     string Id,
     string Source,
     string Target,
     bool DisableTargetIdentityInsert,
-    bool DisableConstraintCheck
+    bool DisableConstraintCheck,
+    bool DeleteInsteadOfTruncate
     );

--- a/src/SqlBulkSyncFunction/Models/Schema/TableSchema.cs
+++ b/src/SqlBulkSyncFunction/Models/Schema/TableSchema.cs
@@ -5,36 +5,91 @@ using SqlBulkSyncFunction.Models.Job;
 
 namespace SqlBulkSyncFunction.Models.Schema;
 
+/// <summary>
+/// Schema and pre-built SQL statements for syncing a single source/target table pair.
+/// </summary>
 public record TableSchema
 {
+    /// <summary>Human-readable scope label for logging.</summary>
     public string Scope { get; }
+
+    /// <summary>Source table name.</summary>
     public string SourceTableName { get; }
+
+    /// <summary>Target table name.</summary>
     public string TargetTableName { get; }
+
+    /// <summary>Columns included in sync operations.</summary>
     public Column[] Columns { get; }
+
+    /// <summary>Staging table for new or updated rows.</summary>
     public string SyncNewOrUpdatedTableName { get; }
+
+    /// <summary>Staging table for deleted row keys.</summary>
     public string SyncDeletedTableName { get; }
+
+    /// <summary>SQL to drop the new/updated staging table.</summary>
     public string DropNewOrUpdatedTableStatement { get; }
+
+    /// <summary>SQL to drop the deleted staging table.</summary>
     public string DropDeletedTableStatement { get; }
+
+    /// <summary>SQL merge statement for incremental sync.</summary>
     public string MergeNewOrUpdateStatement { get; }
+
+    /// <summary>SQL delete statement for incremental sync.</summary>
     public string DeleteStatement { get; }
+
+    /// <summary>SQL to select new/updated rows from source.</summary>
     public string SourceNewOrUpdatedSelectStatement { get; }
+
+    /// <summary>SQL to select deleted row keys from source.</summary>
     public string SourceDeletedSelectStatement { get; }
+
+    /// <summary>SQL to select all rows from source.</summary>
     public string SourceSelectAllStatement { get; }
+
+    /// <summary>SQL to create the new/updated staging table.</summary>
     public string CreateNewOrUpdatedSyncTableStatement { get; }
+
+    /// <summary>SQL to create the deleted staging table.</summary>
     public string CreateDeletedSyncTableStatement { get; }
-    public string TruncateTargetTableStatement { get; }
+
+    /// <summary>SQL batch to clear the target table during seed (TRUNCATE or DELETE + reseed).</summary>
+    public string ClearTargetTableStatement { get; }
+
+    /// <summary>SQL to detect whether sync staging tables already exist.</summary>
     public string SyncTableExistStatement { get; }
+
+    /// <summary>Change tracking version from source.</summary>
     public TableVersion SourceVersion { get; }
+
+    /// <summary>Persisted sync version on target.</summary>
     public TableVersion TargetVersion { get; }
+
+    /// <summary>Bulk copy batch size.</summary>
     public int BatchSize { get; }
+
+    /// <summary>Whether identity insert is disabled during merge.</summary>
     public bool DisableTargetIdentityInsert { get; }
+
+    /// <summary>Whether constraint checking is disabled during merge.</summary>
     public bool DisableConstraintCheck { get; }
+
+    /// <summary>When true, seed uses DELETE + reseed instead of TRUNCATE.</summary>
+    public bool UseDeleteInsteadOfTruncate { get; }
+
+    /// <summary>Tables with foreign keys referencing the target (used for seed clear).</summary>
+    public string[] ReferencingTables { get; }
+
     private TableSchema(
         SyncJobTable table,
         Column[] columns,
         TableVersion sourceVersion,
         TableVersion targetVersion,
-        int? batchSize
+        int? batchSize,
+        string[] referencingTables,
+        bool useDeleteInsteadOfTruncate
         )
     {
         var bufferName = table.Target.Replace("[", "").Replace("]", "");
@@ -49,6 +104,8 @@ public record TableSchema
         TargetTableName = table.Target;
         DisableTargetIdentityInsert = table.DisableTargetIdentityInsert;
         DisableConstraintCheck = table.DisableConstraintCheck;
+        ReferencingTables = referencingTables;
+        UseDeleteInsteadOfTruncate = useDeleteInsteadOfTruncate;
         SyncNewOrUpdatedTableName = FormattableString.Invariant($"sync.[{bufferName}_{DateTime.UtcNow:yyyyMMdd}_{targetVersion.CurrentVersion:00000000}_NewOrUpdated]");
         SyncDeletedTableName = FormattableString.Invariant($"sync.[{bufferName}_{DateTime.UtcNow:yyyyMMdd}_{targetVersion.CurrentVersion:00000000}_DeletedTable]");
         Columns = columns;
@@ -65,12 +122,15 @@ public record TableSchema
         DeleteStatement = this.GetDeleteStatement();
         DropNewOrUpdatedTableStatement = SyncNewOrUpdatedTableName.GetDropStatement();
         DropDeletedTableStatement = SyncDeletedTableName.GetDropStatement();
-        TruncateTargetTableStatement = this.GetTruncateTargetTableStatement();
+        ClearTargetTableStatement = this.GetClearTargetTableStatement(UseDeleteInsteadOfTruncate, ReferencingTables);
         SyncTableExistStatement = this.GetSyncTableExistStatement();
         BatchSize = batchSize ?? 1000;
     }
 
 
+    /// <summary>
+    /// Loads schema metadata and pre-built SQL from source and target connections.
+    /// </summary>
     public static TableSchema LoadSchema(
         SqlConnection sourceConn,
         SqlConnection targetConn,
@@ -81,12 +141,16 @@ public record TableSchema
     {
         var columns = sourceConn.GetColumns(syncTable.Source);
         var targetVersion = targetConn.GetTargetVersion(syncTable.Target);
+        var referencingTables = targetConn.GetReferencingTables(syncTable.Target);
+        var useDeleteInsteadOfTruncate = syncTable.DeleteInsteadOfTruncate || referencingTables.Length > 0;
         return new TableSchema(
             syncTable,
             columns,
             sourceConn.GetSourceVersion(syncTable.Source, globalChangeTracking, columns),
             targetVersion,
-            batchSize
+            batchSize,
+            referencingTables,
+            useDeleteInsteadOfTruncate
             );
     }
 }

--- a/src/SqlBulkSyncFunction/Services/ProcessSyncJobService.cs
+++ b/src/SqlBulkSyncFunction/Services/ProcessSyncJobService.cs
@@ -126,7 +126,7 @@ public partial class ProcessSyncJobService(
 
     private void SeedTable(SqlConnection targetConn, TableSchema tableSchema, SqlConnection sourceConn, object scope)
     {
-        targetConn.TruncateTargetTable(tableSchema, scope, logger);
+        targetConn.ClearTargetTable(tableSchema, scope, logger);
         sourceConn.BulkCopyDataDirect(targetConn, tableSchema, scope, logger);
     }
 


### PR DESCRIPTION
Seed jobs failed when the target table was referenced by foreign keys, because SQL Server does not allow TRUNCATE on referenced tables.

Detect incoming FKs on the target at schema load and choose the clear strategy automatically. When DELETE is required, disable constraints on referencing tables, delete all rows, reseed identity when present, then re-enable constraints. TRUNCATE remains the default when no incoming FKs exist.

- Add GetReferencingTables query and GetClearTargetTableStatement builder
- Replace TruncateTargetTable with ClearTargetTable and ClearTargetTableStatement
- Add optional DeleteInsteadOfTruncateTables per-table config override
- Expose deleteInsteadOfTruncate in sync job config API
- Document new setting in README