### PR TITLE
feat(seed): make DBCC CHECKIDENT reseed opt-in per table

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ The function is configured through Azure App Settings / Environment variables, y
 | `SyncJobsConfig__Jobs__[key]__Tables__[key]`                             | Fully qualified name of table to sync                                                                                                        | `dbo.MyTable`                                                                |
 | `SyncJobsConfig__Jobs__[key]__DisableTargetIdentityInsertTables__[key]`  | Optional, per table. When `true`, merge does not use `IDENTITY_INSERT` on target (use when target has no identity column but source does).   | `true` or `false`                                                            |
 | `SyncJobsConfig__Jobs__[key]__DisableConstraintCheckTables__[key]`       | Optional, per table. When `true`, disables constraint checking during merge. Useful for tables with foreign key dependencies.                | `true` or `false`                                                            |
-| `SyncJobsConfig__Jobs__[key]__DeleteInsteadOfTruncateTables__[key]`      | Optional, per table. When `true`, forces DELETE + identity reseed instead of TRUNCATE when clearing target during seed. Auto-enabled when incoming FKs are detected. | `true` or `false`                                                            |
+| `SyncJobsConfig__Jobs__[key]__DeleteInsteadOfTruncateTables__[key]`      | Optional, per table. When `true`, forces DELETE instead of TRUNCATE when clearing target during seed. Auto-enabled when incoming FKs are detected. | `true` or `false`                                                            |
+| `SyncJobsConfig__Jobs__[key]__ReseedTargetIdentityAfterClearTables__[key]` | Optional, per table. When `true`, runs `DBCC CHECKIDENT` reseed after clearing the target during seed (only when target has an identity column). | `true` or `false`                                                            |
 
 
 > Note:
@@ -45,7 +46,9 @@ The function is configured through Azure App Settings / Environment variables, y
 >
 > **DisableConstraintCheckTables**: Omit or set to `false` to keep constraints enabled during merge (default). Set to `true` per table when syncing tables with foreign key dependencies that may cause constraint violations due to merge order.
 >
-> **DeleteInsteadOfTruncateTables**: During seed, the target table is cleared before bulk copy. `TRUNCATE` is used by default when the target is not referenced by foreign keys. When the target is referenced by other tables (detected automatically at schema load), or when this flag is `true`, the service uses `DELETE` with `NOCHECK`/`CHECK` on referencing tables and `DBCC CHECKIDENT` reseed when the target has an identity column. Set to `true` to force the delete path (e.g. replication or other TRUNCATE restrictions without FK).
+> **DeleteInsteadOfTruncateTables**: During seed, the target table is cleared before bulk copy. `TRUNCATE` is used by default when the target is not referenced by foreign keys. When the target is referenced by other tables (detected automatically at schema load), or when this flag is `true`, the service uses `DELETE` with `NOCHECK`/`CHECK` on referencing tables. Set to `true` to force the delete path (e.g. replication or other TRUNCATE restrictions without FK).
+>
+> **ReseedTargetIdentityAfterClearTables**: Omit or set to `false` to leave the identity seed unchanged after clear (default). Set to `true` per table to run `DBCC CHECKIDENT` reseed to 0 after delete-based clear when the target has an identity column.
 >
 > Configuration from KeyVault replace `__` with `--` i.e. `SyncJobsConfig--Jobs--MySync--Tables--MyTable`
 

--- a/src/SqlBulkSyncFunction/Functions/GetSyncJobConfig.GetJobConfig.cs
+++ b/src/SqlBulkSyncFunction/Functions/GetSyncJobConfig.GetJobConfig.cs
@@ -35,7 +35,8 @@ public partial class GetSyncJobConfig
                         Target: jobConfig.TargetTables?.TryGetValue(value.Key, out var target) == true && !string.IsNullOrWhiteSpace(target) ? target : value.Value,
                         DisableTargetIdentityInsert: jobConfig.DisableTargetIdentityInsertTables.GetValueOrDefault(value.Key),
                         DisableConstraintCheck: jobConfig.DisableConstraintCheckTables.GetValueOrDefault(value.Key),
-                        DeleteInsteadOfTruncate: jobConfig.DeleteInsteadOfTruncateTables.GetValueOrDefault(value.Key)
+                        DeleteInsteadOfTruncate: jobConfig.DeleteInsteadOfTruncateTables.GetValueOrDefault(value.Key),
+                        ReseedTargetIdentityAfterClear: jobConfig.ReseedTargetIdentityAfterClearTables.GetValueOrDefault(value.Key)
                     )
                 ) ?? [];
             return new OkObjectResult(

--- a/src/SqlBulkSyncFunction/Helpers/SqlStatementExtensions.cs
+++ b/src/SqlBulkSyncFunction/Helpers/SqlStatementExtensions.cs
@@ -516,7 +516,7 @@ public static class SqlStatementExtensions
 
     /// <summary>
     /// Builds the SQL batch used to clear the target table during seed operations.
-    /// Uses TRUNCATE when safe; otherwise DELETE with NOCHECK on referencing tables and identity reseed.
+    /// Uses TRUNCATE when safe; otherwise DELETE with NOCHECK on referencing tables and optional identity reseed.
     /// </summary>
     /// <param name="tableSchema">Target table schema.</param>
     /// <param name="useDeleteInsteadOfTruncate">When true, use DELETE instead of TRUNCATE.</param>
@@ -542,7 +542,7 @@ public static class SqlStatementExtensions
 
         _ = statement.AppendLine(FormattableString.Invariant($"DELETE FROM {tableSchema.TargetTableName};"));
 
-        if (tableSchema.Columns.Any(column => column.IsIdentity))
+        if (tableSchema.ReseedTargetIdentityAfterClear && tableSchema.Columns.Any(column => column.IsIdentity))
         {
             _ = statement.AppendLine(FormattableString.Invariant($"DBCC CHECKIDENT ('{tableSchema.TargetTableName}', RESEED, 0);"));
         }

--- a/src/SqlBulkSyncFunction/Helpers/SyncJobConfigExtensions.cs
+++ b/src/SqlBulkSyncFunction/Helpers/SyncJobConfigExtensions.cs
@@ -60,6 +60,12 @@ public static class SyncJobConfigExtensions
             StringComparer.OrdinalIgnoreCase
         );
 
+        var reseedTargetIdentityAfterClearTables = job.ReseedTargetIdentityAfterClearTables?.ToLookup(
+            key => key.Key,
+            value => value.Value,
+            StringComparer.OrdinalIgnoreCase
+        );
+
         return [.. job.Tables.Select(
             sourceTable => new SyncJobTable(
                 sourceTable.Key,
@@ -71,7 +77,8 @@ public static class SyncJobConfigExtensions
                 },
                 disableTargetIdentityInsertTables.GetValueOrDefault(sourceTable.Key),
                 disableConstraintCheckTables.GetValueOrDefault(sourceTable.Key),
-                deleteInsteadOfTruncateTables.GetValueOrDefault(sourceTable.Key)
+                deleteInsteadOfTruncateTables.GetValueOrDefault(sourceTable.Key),
+                reseedTargetIdentityAfterClearTables.GetValueOrDefault(sourceTable.Key)
             )
         )];
     }

--- a/src/SqlBulkSyncFunction/Models/Job/SyncJobConfig.cs
+++ b/src/SqlBulkSyncFunction/Models/Job/SyncJobConfig.cs
@@ -11,6 +11,7 @@ public record SyncJobConfig
     public Dictionary<string, bool> DisableTargetIdentityInsertTables { get; init; } = [];
     public Dictionary<string, bool> DisableConstraintCheckTables { get; init; } = [];
     public Dictionary<string, bool> DeleteInsteadOfTruncateTables { get; init; } = [];
+    public Dictionary<string, bool> ReseedTargetIdentityAfterClearTables { get; init; } = [];
     public int? BatchSize { get; init; }
     public string Area { get; init; }
     public bool? Manual { get; init; }

--- a/src/SqlBulkSyncFunction/Models/Job/SyncJobConfigResponse.cs
+++ b/src/SqlBulkSyncFunction/Models/Job/SyncJobConfigResponse.cs
@@ -10,13 +10,15 @@ namespace SqlBulkSyncFunction.Models.Job;
 /// <param name="Target">Target table name.</param>
 /// <param name="DisableTargetIdentityInsert">Whether target identity insert is disabled for this table.</param>
 /// <param name="DisableConstraintCheck">Whether constraint checking is disabled during merge operations for this table.</param>
-/// <param name="DeleteInsteadOfTruncate">Whether DELETE + reseed is used instead of TRUNCATE when clearing target during seed.</param>
+/// <param name="DeleteInsteadOfTruncate">Whether DELETE is used instead of TRUNCATE when clearing target during seed.</param>
+/// <param name="ReseedTargetIdentityAfterClear">Whether DBCC CHECKIDENT runs after clearing the target during seed.</param>
 public record SyncJobConfigTableDto(
     [property: JsonPropertyName("source")] string Source,
     [property: JsonPropertyName("target")] string Target,
     [property: JsonPropertyName("disableTargetIdentityInsert")] bool DisableTargetIdentityInsert,
     [property: JsonPropertyName("disableConstraintCheck")] bool DisableConstraintCheck,
-    [property: JsonPropertyName("deleteInsteadOfTruncate")] bool DeleteInsteadOfTruncate
+    [property: JsonPropertyName("deleteInsteadOfTruncate")] bool DeleteInsteadOfTruncate,
+    [property: JsonPropertyName("reseedTargetIdentityAfterClear")] bool ReseedTargetIdentityAfterClear
 );
 
 /// <summary>

--- a/src/SqlBulkSyncFunction/Models/Job/SyncJobTable.cs
+++ b/src/SqlBulkSyncFunction/Models/Job/SyncJobTable.cs
@@ -8,12 +8,14 @@ namespace SqlBulkSyncFunction.Models.Job;
 /// <param name="Target">Target table name.</param>
 /// <param name="DisableTargetIdentityInsert">Whether to disable identity insert on target table during sync.</param>
 /// <param name="DisableConstraintCheck">Whether to disable constraint checking on target table during merge operations.</param>
-/// <param name="DeleteInsteadOfTruncate">Whether to use DELETE + reseed instead of TRUNCATE when clearing target during seed.</param>
+/// <param name="DeleteInsteadOfTruncate">Whether to use DELETE instead of TRUNCATE when clearing target during seed.</param>
+/// <param name="ReseedTargetIdentityAfterClear">Whether to run DBCC CHECKIDENT after clearing the target during seed.</param>
 public record SyncJobTable(
     string Id,
     string Source,
     string Target,
     bool DisableTargetIdentityInsert,
     bool DisableConstraintCheck,
-    bool DeleteInsteadOfTruncate
+    bool DeleteInsteadOfTruncate,
+    bool ReseedTargetIdentityAfterClear
     );

--- a/src/SqlBulkSyncFunction/Models/Schema/TableSchema.cs
+++ b/src/SqlBulkSyncFunction/Models/Schema/TableSchema.cs
@@ -55,7 +55,7 @@ public record TableSchema
     /// <summary>SQL to create the deleted staging table.</summary>
     public string CreateDeletedSyncTableStatement { get; }
 
-    /// <summary>SQL batch to clear the target table during seed (TRUNCATE or DELETE + reseed).</summary>
+    /// <summary>SQL batch to clear the target table during seed (TRUNCATE or DELETE, optional reseed).</summary>
     public string ClearTargetTableStatement { get; }
 
     /// <summary>SQL to detect whether sync staging tables already exist.</summary>
@@ -76,8 +76,11 @@ public record TableSchema
     /// <summary>Whether constraint checking is disabled during merge.</summary>
     public bool DisableConstraintCheck { get; }
 
-    /// <summary>When true, seed uses DELETE + reseed instead of TRUNCATE.</summary>
+    /// <summary>When true, seed uses DELETE instead of TRUNCATE.</summary>
     public bool UseDeleteInsteadOfTruncate { get; }
+
+    /// <summary>When true, seed runs DBCC CHECKIDENT after clearing the target.</summary>
+    public bool ReseedTargetIdentityAfterClear { get; }
 
     /// <summary>Tables with foreign keys referencing the target (used for seed clear).</summary>
     public string[] ReferencingTables { get; }
@@ -106,6 +109,7 @@ public record TableSchema
         DisableConstraintCheck = table.DisableConstraintCheck;
         ReferencingTables = referencingTables;
         UseDeleteInsteadOfTruncate = useDeleteInsteadOfTruncate;
+        ReseedTargetIdentityAfterClear = table.ReseedTargetIdentityAfterClear;
         SyncNewOrUpdatedTableName = FormattableString.Invariant($"sync.[{bufferName}_{DateTime.UtcNow:yyyyMMdd}_{targetVersion.CurrentVersion:00000000}_NewOrUpdated]");
         SyncDeletedTableName = FormattableString.Invariant($"sync.[{bufferName}_{DateTime.UtcNow:yyyyMMdd}_{targetVersion.CurrentVersion:00000000}_DeletedTable]");
         Columns = columns;


### PR DESCRIPTION
Identity reseed after delete-based seed clear was previously automatic when the target had an identity column. That is now a separate, explicit configuration so reseed only runs when requested.

- Add ReseedTargetIdentityAfterClearTables per-table config (default false)
- Gate DBCC CHECKIDENT on ReseedTargetIdentityAfterClear in clear SQL builder
- Wire flag through SyncJobTable, TableSchema, and config API DTO
- Update README to separate delete-vs-truncate from identity reseed behavior