### PR TITLE
fix(sync): skip seed/sync when source change tracking is missing

### DIFF
--- a/src/SqlBulkSyncFunction/Helpers/SchemaExtensions.cs
+++ b/src/SqlBulkSyncFunction/Helpers/SchemaExtensions.cs
@@ -57,6 +57,13 @@ public static class SchemaExtensions
         TableSchema tableSchema
         )
     {
+        if (tableSchema.SourceVersion is null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot persist version state for {tableSchema.TargetTableName}: source version is unknown (table not in change_tracking_tables)."
+                );
+        }
+
         var syncedTableVersion = tableSchema.SourceVersion with
         {
             TableName = tableSchema.TargetTableName
@@ -107,7 +114,8 @@ public static class SchemaExtensions
                         inserted.Queried;
                 """
             )
-            .SingleOrDefault();
+            .SingleOrDefault()
+            ?? throw new Exception($"Failed to persist {syncedTableVersion} (MERGE returned no row)");
 
         if (persistedTableVersion != syncedTableVersion with { Updated = persistedTableVersion.Updated })
         {

--- a/src/SqlBulkSyncFunction/Services/ProcessSyncJobService.cs
+++ b/src/SqlBulkSyncFunction/Services/ProcessSyncJobService.cs
@@ -84,14 +84,15 @@ public partial class ProcessSyncJobService(
                         {
                             LogBeginTableSchemaScope(schedule, id, area, tableSchema.Scope);
 
-                            if (syncJob.Seed)
-                            {
-                                SeedTable(targetConn, tableSchema, sourceConn, scope);
-                            }
-                            else if (tableSchema.SourceVersion == null)
+                            if (tableSchema.SourceVersion is null)
                             {
                                 LogUnknownSourceVersion(schedule, id, area, tableSchema.Scope);
                                 return;
+                            }
+
+                            if (syncJob.Seed)
+                            {
+                                SeedTable(targetConn, tableSchema, sourceConn, scope);
                             }
                             else if (tableSchema.SourceVersion.CurrentVersion.Equals(tableSchema.TargetVersion.CurrentVersion))
                             {


### PR DESCRIPTION
Guard null SourceVersion before any table work so Seed no longer mutates the target then NREs in PersistsSourceTargetVersionState. Also throw clear errors if persist is called without a source version or MERGE returns no row.