### PR TITLE
fix: correct staging table column types for incremental sync bulk copy

### DIFF
--- a/src/SqlBulkSyncFunction/Helpers/SchemaExtensions.cs
+++ b/src/SqlBulkSyncFunction/Helpers/SchemaExtensions.cs
@@ -227,12 +227,35 @@ public static class SchemaExtensions
                                                         ELSE CAST(c.max_length as varchar(max))
                                                     END
                                                     +')'
+                                        WHEN tp.name IN('varbinary', 'binary')
+                                            THEN    tp.name +
+                                                    '(' +
+                                                    CASE c.max_length
+                                                        WHEN -1 THEN 'max'
+                                                        ELSE CAST(c.max_length as varchar(max))
+                                                    END
+                                                    +')'
+                                        WHEN tp.name IN('char')
+                                            THEN    tp.name +
+                                                    '(' +
+                                                    CAST(c.max_length as varchar(max))
+                                                    +')'
+                                        WHEN tp.name IN('nchar')
+                                            THEN    tp.name +
+                                                    '(' +
+                                                    CAST(c.max_length / 2 as nvarchar(max))
+                                                    +')'
                                         WHEN tp.name = 'decimal'
                                             THEN    tp.name +
                                                     '(' +
                                                         CAST(c.precision as nvarchar(max))
                                                         + ', ' +
                                                         CAST(c.scale as nvarchar(max))
+                                                    +')'
+                                        WHEN tp.name IN('datetime2', 'datetimeoffset', 'time')
+                                            THEN    tp.name +
+                                                    '(' +
+                                                    CAST(c.scale as nvarchar(max))
                                                     +')'
                                         ELSE tp.name
                                     END AS Type,

--- a/src/SqlBulkSyncFunction/Helpers/SqlCommandExtensions.cs
+++ b/src/SqlBulkSyncFunction/Helpers/SqlCommandExtensions.cs
@@ -99,47 +99,60 @@ public static class SqlCommandExtensions
         TableSchema tableSchema,
         object scope,
         ILogger logger
-        ) => Array.ForEach(
-            [
-                new
-                {
-                    Name = tableSchema.SyncNewOrUpdatedTableName,
-                    SelectStatement = tableSchema.SourceNewOrUpdatedSelectStatement,
-                    Description = "new or updated"
-                },
-                new
-                {
-                    Name = tableSchema.SyncDeletedTableName,
-                    SelectStatement = tableSchema.SourceDeletedSelectStatement,
-                    Description = "deleted"
-                }
-            ],
-            table =>
-            {
-                using var sourceCmd = new SqlCommand
-                {
-                    Connection = sourceConn,
-                    CommandType = CommandType.Text,
-                    CommandText = table.SelectStatement,
-                    CommandTimeout = 500000
-                };
-
-                using var reader = sourceCmd.ExecuteReader();
-
-                using var bcp = new SqlBulkCopy(targetConn, SqlBulkCopyOptions.KeepIdentity, null)
-                {
-                    DestinationTableName = table.Name,
-                    BatchSize = tableSchema.BatchSize,
-                    NotifyAfter = tableSchema.BatchSize,
-                    BulkCopyTimeout = 300,
-                    EnableStreaming = true
-                };
-
-                bcp.SqlRowsCopied += (s, e) => logger.LogInformation("{Scope} {TableName} {RowsCopied} {Description} rows copied", scope, table.Name, e.RowsCopied, table.Description);
-                bcp.WriteToServer(reader);
-                logger.LogInformation("{Scope} Bulk copy complete for {Description}.", scope, table.Description);
-            }
+        )
+    {
+        BulkCopyChangesSegment(
+            sourceConn,
+            targetConn,
+            tableSchema,
+            tableSchema.SyncNewOrUpdatedTableName,
+            tableSchema.SourceNewOrUpdatedSelectStatement,
+            tableSchema.Columns,
+            scope,
+            logger
             );
+
+        BulkCopyChangesSegment(
+            sourceConn,
+            targetConn,
+            tableSchema,
+            tableSchema.SyncDeletedTableName,
+            tableSchema.SourceDeletedSelectStatement,
+            [.. tableSchema.Columns.Where(column => column.IsPrimary)],
+            scope,
+            logger
+            );
+    }
+
+    private static void BulkCopyChangesSegment(
+        SqlConnection sourceConn,
+        SqlConnection targetConn,
+        TableSchema tableSchema,
+        string destinationTableName,
+        string selectStatement,
+        Column[] columnMappings,
+        object scope,
+        ILogger logger
+        )
+    {
+        using var sourceCmd = new SqlCommand
+        {
+            Connection = sourceConn,
+            CommandType = CommandType.Text,
+            CommandText = selectStatement,
+            CommandTimeout = 500000
+        };
+
+        WriteBulkCopy(
+            sourceCmd,
+            targetConn,
+            tableSchema,
+            destinationTableName,
+            columnMappings,
+            scope,
+            logger
+            );
+    }
 
     public static bool SyncTablesExist(
         this SqlConnection targetConn,
@@ -302,6 +315,7 @@ public static class SqlCommandExtensions
             targetConn,
             tableSchema,
             tableSchema.TargetTableName,
+            tableSchema.Columns,
             scope,
             logger
             );
@@ -335,6 +349,7 @@ public static class SqlCommandExtensions
             targetConn,
             tableSchema,
             tableSchema.SyncNewOrUpdatedTableName,
+            tableSchema.Columns,
             scope,
             logger
             );
@@ -424,6 +439,7 @@ public static class SqlCommandExtensions
         SqlConnection targetConn,
         TableSchema tableSchema,
         string destinationTableName,
+        Column[] columnMappings,
         object scope,
         ILogger logger
     )
@@ -439,7 +455,7 @@ public static class SqlCommandExtensions
             EnableStreaming = true
         };
 
-        foreach (var tableSchemaColumn in tableSchema.Columns)
+        foreach (var tableSchemaColumn in columnMappings)
         {
             _ = bcp.ColumnMappings.Add(
                 tableSchemaColumn.Name,


### PR DESCRIPTION
Emit full SQL type definitions (varbinary/binary, char/nchar, datetime2/time) when building sync staging tables so columns like PasswordHash are not created as varbinary(1). Route incremental bulk copy through WriteBulkCopy with explicit column mappings, matching the seed path.